### PR TITLE
Remove ES 6 in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var hotjar = require('./src/react-hotjar');
 
 module.exports = {
 	hotjar: {
-		initialize: (initialize = (id, sv) => {
+		initialize: (initialize = function(id, sv){
 			hotjar(id, sv);
 		})
 	}


### PR DESCRIPTION
create-react-app build scripts reject ES6, so I removed the arrow function, and replaced it with a standard JS function. This allows create-react-app to successfully minify the module and allows the project to build.