### PR TITLE
Replace arrow function

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@ var hotjar = require('./src/react-hotjar');
 
 module.exports = {
 	hotjar: {
-		initialize: (initialize = (id, sv) => {
+		initialize: function initialize(id, sv) {
 			hotjar(id, sv);
-		})
+		}
 	}
 };


### PR DESCRIPTION
Currently not every browser supports arrow functions, see https://caniuse.com/#feat=arrow-functions=arrow-functions. This PR creates support for older browsers.