### PR TITLE
Update react-hotjar.js -- Make es5 compatible

### DIFF
--- a/src/react-hotjar.js
+++ b/src/react-hotjar.js
@@ -8,7 +8,7 @@ module.exports = function(id, sv) {
 		h._hjSettings = { hjid: id, hjsv: sv };
 		h._scriptPath = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
 		if(!document.querySelector(
-			'script[src*="' + h._scriptPath + '"]',
+			'script[src*="' + h._scriptPath + '"]'
 		)){
 			a = o.getElementsByTagName('head')[0];
 			r = o.createElement('script');


### PR DESCRIPTION
After the last update, this tangling comma was added and it started failing the build of our project.

After further investigating it was understood that this comma is not accepted for es5 environments and should not be here.

This is the error I get when trying to use this version:

@abdalla can you check this, please?!

```
ERROR in vendors.f285b4c8d82e8d031f35.js from Terser

Unexpected token: punc ()) [./node_modules/react-hotjar/src/react-hotjar.js:12,0][vendors.f285b4c8d82e8d031f35.js:289966,2].
```