### PR TITLE
fix ie11 compilation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 var hotjar = require('./src/react-hotjar');
 
-function hj(...params) {
+function hj() {
+	var params = Array.prototype.slice.call(arguments);
 	if (!window.hj) {
 		throw new Error('Hotjar is not initialized');
 	}
 
-	window.hj(...params);
+	window.hj.apply(undefined, params)
 }
 
 module.exports = {


### PR DESCRIPTION
node_modules is excluded from transcompilation.
This fix resolves it by preventing using spread operator