### PR TITLE
Add helper function to check if Hotjar has been intialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ hotjar.event('button-click');
 
 // Update SPA state
 hotjar.stateChange('/my/page');
+
+// Check if Hotjar has been initialized before calling its methods
+if (hotjar.initialized()) {
+  hotjar.identify('USER_ID', { userProperty: 'value' });
+}
 ```
 - hjid: Stands for 'Hotjar ID' - Your site's ID. This is the ID which tells Hotjar which site settings it should load and where it should save the data collected.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,11 @@ export module hotjar {
   export function initialize(hjid: number, hjsv: number): void;
 
   /**
+   * Check if Hotjar has been initialized
+   */
+  export function initialized(): boolean;
+
+  /**
    * Identify user
    * @param userId Unique ID of a user
    * @param properties Additional properties describing your user

--- a/index.js
+++ b/index.js
@@ -6,13 +6,16 @@ function hj() {
 		throw new Error('Hotjar is not initialized');
 	}
 
-	window.hj.apply(undefined, params)
+	window.hj.apply(undefined, params);
 }
 
 module.exports = {
 	hotjar: {
 		initialize: function initialize(id, sv) {
 			hotjar(id, sv);
+		},
+		initialized: function initialized() {
+			return typeof window.hj === 'function';
 		},
 		identify: function identify(userId, properties) {
 			hj('identify', userId, properties);


### PR DESCRIPTION
If you only initialize Hotjar conditionally based certain criteria (e.g. only on a production environment), you need to check it's been initialized before using the module elsewhere in the codebase, otherwise it will throw an error. This adds a helper function to make that check.