### PR TITLE
Allow userId to be null

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ export module hotjar {
    * @param properties Additional properties describing your user
    */
   export function identify(
-    userId: string,
+    userId: string | null,
     properties: Record<string, any>
   ): void;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-hotjar",
-	"version": "5.1.0",
+	"version": "5.1.1",
 	"description": "Small component to implement Hotjar into your react application",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Love your work with the package.

Was just wondering what your thoughts are on allowing `userId` to be nullable when making a `hj('identify')` API call to Hotjar.

As mentioned in the documentation on Hotjar, `userId` can be set as null should it not exist.

> The second should be a string containing the user id for a user on your site, from your own user database, or null if it is not known.

Reference: [https://help.hotjar.com/hc/en-us/articles/360033640653](https://help.hotjar.com/hc/en-us/articles/360033640653)