### PR TITLE
fix eager evaluation of window

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = {
 			hotjar(id, sv);
 		},
 		initialized: function initialized() {
-			return typeof window.hj === 'function';
+			return typeof window !== 'undefined' && typeof window?.hj === 'function';
 		},
 		identify: function identify(userId, properties) {
 			hj('identify', userId, properties);


### PR DESCRIPTION
This partially resolves #26 though not fully. The benefit of using `typeof window` is that it only gets the type instead of evaluating the reference to window. `typeof window?.` causes it to try and evaluate `window` so it can check the potential property. 

I think this project serves as a decent core implementation but requires wrapper hooks to use, eg I have hooks like

```js
import { useEffect, useState } from 'react'
import { hotjar } from 'react-hotjar'

export function useMounted() {
  const [mounted, setMounted] = useState(false)
  useEffect(() => setMounted(true), [])

  return mounted
}

function hotjarInitialized() {
  return typeof window !== 'undefined' && typeof window?.hj === 'function'
}

export function useHotjarInitialize() {
  const mounted = useMounted()
  const [ready, setReady] = useState(false)
  const initialized = hotjarInitialized()

  useEffect(() => {
    if (!mounted || initialized || ready) return undefined

    hotjar.initialize(MYCODE, 6)
    setReady(true)
  }, [mounted, initialized, ready])

  return ready || initialized
}
```

Because there's some sort of weird need to keep track of initialized unless you subscribe to `window.hj` since it's possible for it to be undefined in a different hook 🤷 (my solution at the moment is to setup a hook that polls hotjarInitialized until it's true, and then use that across other hook wrappers like identify and state changes).

A better implementation would probably be more stateful or an observable ~~proxy(?)~~ object of some sort. Maybe singleton hooks? Just spitballing.