### PR TITLE
Fix build issue with 'hotjar is already defined'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import hotjar from './src/react-hotjar';
+import initHotjar from './src/react-hotjar';
 
 function hj() {
 	const params = Array.prototype.slice.call(arguments);
@@ -10,7 +10,7 @@ function hj() {
 
 export const hotjar = {
 	initialize: function initialize(id, sv) {
-		hotjar(id, sv);
+		initHotjar(id, sv);
 	},
 	initialized: function initialized() {
 		return typeof window !== 'undefined' && typeof window.hj === 'function';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-hotjar",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"description": "Small component to implement Hotjar into your react application",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
When trying to build with `v6.0.0`, `react-hotjar` is complaining stating

> ERROR in ./node_modules/react-hotjar/index.js 11:13
Module parse failed: Identifier 'hotjar' has already been declared (11:13)

This was because the imported `hotjar` is clashing with `export const hotjar`. The fix done is rename the imported `hotjar` to `initHotjar` and updating its respective calls accordingly.

Not sure how you want to test this but give it a go 🙏 