### PR TITLE
Fix type definition for options prop in initialize function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ if (hotjar.initialized()) {
 ```
 `Options` is an object with the following properties:
 
-- `hjid`: Stands for 'Hotjar ID' - Your site's ID. This is the ID which tells Hotjar which site settings it should load and where it should save the data collected.
+- `id`: Stands for 'Hotjar ID' - Your site's ID. This is the ID which tells Hotjar which site settings it should load and where it should save the data collected.
 
-- `hjsv`: Stands for 'Hotjar Snippet Version' - The version of the Tracking Code you are using. This is only needed if Hotjar ever updates the Tracking Code and needs to discontinue older ones. Knowing which version your site includes allows hotjar team to contact you and inform you accordingly.
+- `sv`: Stands for 'Hotjar Snippet Version' - The version of the Tracking Code you are using. This is only needed if Hotjar ever updates the Tracking Code and needs to discontinue older ones. Knowing which version your site includes allows hotjar team to contact you and inform you accordingly.
 
 - `debug`: Stands for 'Debug' - This is a boolean value that tells Hotjar whether to enable the debug mode for the Tracking Code. When set to true, the debug mode will send data to Hotjar regardless of any privacy settings. This is useful when you want to test the Tracking Code and see if it's working as expected. Optional.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,12 @@
 export module hotjar {
   /**
    * Initialize Hotjar tracking.
-   * @param hjid This is the ID which tells Hotjar which site settings it should load and where it should save the data collected.
-   * @param hjsv The version of the Tracking Code you are using. This is only needed if Hotjar ever updates the Tracking Code and needs to discontinue older ones. Knowing which version your site includes allows hotjar team to contact you and inform you accordingly.
+   * @param id This is the ID which tells Hotjar which site settings it should load and where it should save the data collected.
+   * @param sv The version of the Tracking Code you are using. This is only needed if Hotjar ever updates the Tracking Code and needs to discontinue older ones. Knowing which version your site includes allows hotjar team to contact you and inform you accordingly.
    * @param nonce This is Content Security Policy nonce value.
    * @param debug [debug=false] Used to enable debug mode
    */
-  export function initialize({hjid , hjsv, debug, nonce}: { hjid: number, hjsv: number, debug?: boolean, nonce?: string}): void;
+  export function initialize({id, sv, debug, nonce}: { id: number, sv: number, debug?: boolean, nonce?: string}): void;
 
   /**
    * Check if Hotjar has been initialized


### PR DESCRIPTION
The type definition for the options prop in the initialize function was incorrect. The prop names 'id' and 'sv' were incorrectly defined as 'hjid' and 'hjsv', respectively, in the type definition.

This discrepancy between the actual prop names and their type definition led to a type error being thrown. To resolve this issue, the type definition has been updated to match the correct prop names.

The incorrect prop names in the type definition have been changed from 'hjid' and 'hjsv' to 'id' and 'sv', aligning them with the actual prop names used in the initialize function.

By fixing the type definition, the code now accurately reflects the expected prop names, eliminating the type error that was occurring.

These changes ensure that the type definition for the options prop in the initialize function is correct and matches the actual prop names being used.